### PR TITLE
test to isolate hang in streaming client

### DIFF
--- a/finagle-example/BUILD
+++ b/finagle-example/BUILD
@@ -4,3 +4,9 @@ target(name='finagle-example',
     'finagle/finagle-example/src/main/scala',
   ]
 )
+
+target(name='tests',
+  dependencies=[
+    'finagle/finagle-example/src/test/scala'
+  ]
+)

--- a/finagle-example/README
+++ b/finagle-example/README
@@ -10,3 +10,6 @@ If the example requires a command line parameter, do this:
 
 If you are running a server and a client, start the server in one terminal, then start the client in another.
 
+# Tests
+
+% sbt "project finagle-example" test

--- a/finagle-example/src/test/scala/com/twitter/finagle/example/http/HttpStreamingTest.scala
+++ b/finagle-example/src/test/scala/com/twitter/finagle/example/http/HttpStreamingTest.scala
@@ -1,0 +1,34 @@
+package com.twitter.finagle.example.http
+
+import com.twitter.concurrent.AsyncStream
+import com.twitter.conversions.time._
+import com.twitter.finagle.http.{Method, Request, Response, Status}
+import com.twitter.finagle.{Http, Service}
+import com.twitter.io.{Buf, Reader}
+import com.twitter.util.{Await, Future, JavaTimer}
+import org.mockito.Mockito._
+import org.scalatest.FunSuite
+import org.scalatest.mock.MockitoSugar
+import scala.util.Random
+
+class HttpStreamingTest extends FunSuite with MockitoSugar {
+
+  test("does not hang when a client makes two streaming requests") {
+    Http.server
+      .withStreaming(enabled = true)
+      .serve("0.0.0.0:8080", Service.mk[Request, Response] { req =>
+        val writable = Reader.writable() // never gets closed
+        Future.value(Response(req.version, Status.Ok, writable))
+    })
+
+    val client = Http.client.withStreaming(enabled = true).newService(s"/$$/inet/localhost/8080")
+
+    val rsp0 = Await.result(client(Request()), 2.seconds)
+    // rsp0 stream is never closed
+    println("first request succeeded")
+
+    val rsp1 = Await.result(client(Request()), 2.seconds)
+    // hangs
+    println("second request succeeded")
+  }
+}


### PR DESCRIPTION
this test isolates a hung streaming client. steps to reproduce:
1) create a streaming `server`
2) create a streaming `client`
3) make a streaming request, using `client`
4) make a second streaming request using `client`, note hang
